### PR TITLE
Fixes Deprecation warning for #has_rdoc (Rubygems)

### DIFF
--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
     "spec/domainatrix_spec.rb",
     "spec/domainatrix/domain_parser_spec.rb",
     "spec/domainatrix/url_spec.rb"]
-  s.has_rdoc = true
   s.homepage = %q{http://github.com/pauldix/domainatrix}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.5}


### PR DESCRIPTION
*** What type of change is this?

- Bugfix

*** Why is this change necessary?

- To fix the deprecation warning that happens specifically when the
dependence is fetched throught git.

*** How does it address the issue?

- Removing the offensive clause `has_rdoc` from gempspec file.

*** What side effects does this change have?

- None